### PR TITLE
fix go.mod module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module umbrella-associates/opa-spicedb
+module github.com/umbrellaassociates/opa-spicedb
 
 go 1.21
 


### PR DESCRIPTION
This allows projects to import the plugin in a more ergonomic way. 

```
go get github.com/umbrellaassociates/opa-spicedb/plugins
```
returns error:
```
parsing go.mod: module declares its path as: umbrella-associates/opa-spicedb but was required as: github.com/umbrellaassociates/opa-spicedb
```